### PR TITLE
Match onboarding order to therapy setting screen order

### DIFF
--- a/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
+++ b/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
@@ -27,12 +27,12 @@ enum OnboardingScreen: CaseIterable {
     case correctionRangeEditor
     case correctionRangePreMealOverrideInfo
     case correctionRangePreMealOverrideEditor
+    case carbRatioInfo
+    case carbRatioEditor
     case basalRatesInfo
     case basalRatesEditor
     case deliveryLimitsInfo
     case deliveryLimitsEditor
-    case carbRatioInfo
-    case carbRatioEditor
     case insulinSensitivityInfo
     case insulinSensitivityEditor
     case therapySettingsRecap


### PR DESCRIPTION
The order of items shown on the Therapy Settings screen for DIY Loop matches the order for Tidepool Loop.
However, the order of items displayed when onboarding for DIY Loop is different.
Modify DIY LoopOnboarding order to be consistent.